### PR TITLE
Updated dependency for Sequelize to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Daniel Dickison <ddickison@carnegielearning.com>",
   "name": "connect-mysql-session",
   "description": "A MySQL session store for node.js connect.",
-  "version": "0.1.3.1",
+  "version": "0.1.4",
   "repository": {
     "type": "git",
     "url": "git://github.com/alum/connect-mysql-session.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Daniel Dickison <ddickison@carnegielearning.com>",
   "name": "connect-mysql-session",
   "description": "A MySQL session store for node.js connect.",
-  "version": "0.1.3",
+  "version": "0.1.3.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/alum/connect-mysql-session.git"

--- a/package.json
+++ b/package.json
@@ -5,16 +5,16 @@
   "version": "0.1.3",
   "repository": {
     "type": "git",
-    "url": "git://github.com/CarnegieLearning/connect-mysql-session.git"
+    "url": "git://github.com/alum/connect-mysql-session.git"
   },
   "main": "./index.js",
   "engines": {
-    "node": "~0.4"
+    "node": ">=0.4"
   },
   "dependencies": {
-    "sequelize": "~1.1"
+    "sequelize": ">=1.3"
   },
   "devDependencies": {
-    "connect": "~1.6"
+    "connect": ">=1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.4",
   "repository": {
     "type": "git",
-    "url": "git://github.com/alum/connect-mysql-session.git"
+    "url": "git://github.com/CarnegieLearning/connect-mysql-session.git"
   },
   "main": "./index.js",
   "engines": {


### PR DESCRIPTION
There is a problem with the node lib mysql 0.9.4 (dependency of sequelize@<1.3.0) which create zombie db connections resulting in 'too many connections'. This has been solved in sequelize version 1.3.0 and higher.
